### PR TITLE
Update project website to GitHub and add note for old OSDN link

### DIFF
--- a/README
+++ b/README
@@ -47,7 +47,8 @@ DESCRIPTION
     http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2183 , this
     module has removed all support for DES and 3DES ciphers.
 
-    Project website https://osdn.net/projects/ssperl/
+    Project website https://github.com/zhou0/shadowsocks-perl
+    (Old link https://osdn.net/projects/ssperl/ was the link for the project from 2017 to 2025)
 
 SEE ALSO
 

--- a/README.mkdn
+++ b/README.mkdn
@@ -39,7 +39,8 @@ Please note TLS 1.2 has removed IDEA and DES cipher suites. and because of
 CVE-2016-2183,  http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2183
 , this module has removed all support for DES and 3DES ciphers. 
 
-Project website https://osdn.net/projects/ssperl/
+Project website https://github.com/zhou0/shadowsocks-perl
+(Old link https://osdn.net/projects/ssperl/ was the link for the project from 2017 to 2025)
 
 # SEE ALSO
 

--- a/bin/ssclient.pl
+++ b/bin/ssclient.pl
@@ -183,7 +183,8 @@ Please note TLS 1.2 has removed IDEA and DES cipher suites. and because of
 CVE-2016-2183,  http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2183
 , this module has removed all support for DES and 3DES ciphers.
 
-Project website https://osdn.net/projects/ssperl/
+Project website https://github.com/zhou0/shadowsocks-perl
+(Old link https://osdn.net/projects/ssperl/ was the link for the project from 2017 to 2025)
 
 =head1 AUTHOR
 

--- a/bin/ssserver.pl
+++ b/bin/ssserver.pl
@@ -177,7 +177,8 @@ Please note TLS 1.2 has removed IDEA and DES cipher suites. and because of
 CVE-2016-2183,  http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2183
 , this module has removed all support for DES and 3DES ciphers.
 
-Project website https://osdn.net/projects/ssperl/
+Project website https://github.com/zhou0/shadowsocks-perl
+(Old link https://osdn.net/projects/ssperl/ was the link for the project from 2017 to 2025)
 
 =head1 AUTHOR
 

--- a/lib/Net/Shadowsocks.pm
+++ b/lib/Net/Shadowsocks.pm
@@ -390,7 +390,8 @@ Please note TLS 1.2 has removed IDEA and DES cipher suites. and because of
 CVE-2016-2183,  http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2183
 , this module has removed all support for DES and 3DES ciphers. 
 
-Project website https://osdn.net/projects/ssperl/
+Project website https://github.com/zhou0/shadowsocks-perl
+(Old link https://osdn.net/projects/ssperl/ was the link for the project from 2017 to 2025)
 
 =head1 SEE ALSO
 

--- a/lib/Net/Shadowsocks/Client.pm
+++ b/lib/Net/Shadowsocks/Client.pm
@@ -602,7 +602,8 @@ Please note TLS 1.2 has removed IDEA and DES cipher suites. and because of
 CVE-2016-2183,  http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2183
 , this module has removed all support for DES and 3DES ciphers. 
 
-Project website https://osdn.net/projects/ssperl/
+Project website https://github.com/zhou0/shadowsocks-perl
+(Old link https://osdn.net/projects/ssperl/ was the link for the project from 2017 to 2025)
 
 =head1 METHODS
 

--- a/lib/Net/Shadowsocks/Server.pm
+++ b/lib/Net/Shadowsocks/Server.pm
@@ -734,7 +734,8 @@ Please note TLS 1.2 has removed IDEA and DES cipher suites. and because of
 CVE-2016-2183,  http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2183
 , this module has removed all support for DES and 3DES ciphers. 
 
-Project website https://osdn.net/projects/ssperl/
+Project website https://github.com/zhou0/shadowsocks-perl
+(Old link https://osdn.net/projects/ssperl/ was the link for the project from 2017 to 2025)
 
 =head1 METHODS
 


### PR DESCRIPTION
The OSDN project website went dead in 2025. This commit updates the project website link to https://github.com/zhou0/shadowsocks-perl in README, README.mkdn, and all source files with POD documentation. A note has been added indicating that the old OSDN link was the project's home from 2017 to 2025.

---
*PR created automatically by Jules for task [4412407232557247056](https://jules.google.com/task/4412407232557247056) started by @zhou0*