### PR TITLE
Implement xchacha20-ietf-poly1305 encryption method

### DIFF
--- a/README
+++ b/README
@@ -26,7 +26,7 @@ DESCRIPTION
             camellia-128-cfb camellia-128-ctr camellia-128-ofb
             camellia-192-cfb camellia-192-ctr camellia-192-ofb
             camellia-256-cfb camellia-256-ctr camellia-256-ofb
-            chacha20-ietf chacha20-ietf-poly1305
+            chacha20-ietf chacha20-ietf-poly1305 xchacha20-ietf-poly1305
             rc4-md5
             rc6-128-cfb rc6-128-ctr rc6-128-ofb
             rc6-192-cfb rc6-192-ctr rc6-192-ofb

--- a/README.mkdn
+++ b/README.mkdn
@@ -20,7 +20,7 @@ Shadowsocks is a secure transport protocol based on SOCKS Protocol Version 5 (RF
         camellia-128-cfb camellia-128-ctr camellia-128-ofb
         camellia-192-cfb camellia-192-ctr camellia-192-ofb
         camellia-256-cfb camellia-256-ctr camellia-256-ofb
-        chacha20-ietf chacha20-ietf-poly1305
+        chacha20-ietf chacha20-ietf-poly1305 xchacha20-ietf-poly1305
         rc4-md5
         rc6-128-cfb rc6-128-ctr rc6-128-ofb
         rc6-192-cfb rc6-192-ctr rc6-192-ofb
@@ -31,9 +31,6 @@ Shadowsocks is a secure transport protocol based on SOCKS Protocol Version 5 (RF
 
       bf-cfb chacha20 salsa20 
 
-3.The following ciphers recommended by Shadowsocks are not supported yet: 
-
-      xchacha20-ietf-poly1305 
 
 Please note TLS 1.2 has removed IDEA and DES cipher suites. and because of 
 CVE-2016-2183,  http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2183

--- a/bin/ssclient.pl
+++ b/bin/ssclient.pl
@@ -35,7 +35,7 @@ sub main::HELP_MESSAGE()
     print("\tcamellia-256-cfb camellia-256-ctr camellia-256-ofb\n");
     if ($^O ne "MSWin32")
     {
-        print("\tchacha20-ietf chacha20-ietf-poly1305\n");
+        print("\tchacha20-ietf chacha20-ietf-poly1305 xchacha20-ietf-poly1305\n");
     }
 #    print("\trabbit\n");
     print("\trc4-md5\n");
@@ -134,7 +134,7 @@ Usage: ssclient.pl -s SERVER_ADDR -p SERVER_PORT [-b LOCAL_ADDR]
 	camellia-128-cfb camellia-128-ctr camellia-128-ofb
 	camellia-192-cfb camellia-192-ctr camellia-192-ofb
 	camellia-256-cfb camellia-256-ctr camellia-256-ofb
-	chacha20-ietf chacha20-ietf-poly1305
+	chacha20-ietf chacha20-ietf-poly1305 xchacha20-ietf-poly1305
 	rc6-128-cfb rc6-128-ctr rc6-128-ofb
 	rc6-192-cfb rc6-192-ctr rc6-192-ofb
 	rc6-256-cfb rc6-256-ctr rc6-256-ofb
@@ -165,7 +165,7 @@ SOCKS Protocol Version 5 (RFC 1928 ).
 	camellia-128-cfb camellia-128-ctr camellia-128-ofb
 	camellia-192-cfb camellia-192-ctr camellia-192-ofb
 	camellia-256-cfb camellia-256-ctr camellia-256-ofb
-	chacha20-ietf chacha20-ietf-poly1305
+	chacha20-ietf chacha20-ietf-poly1305 xchacha20-ietf-poly1305
 	rc6-128-cfb rc6-128-ctr rc6-128-ofb
 	rc6-192-cfb rc6-192-ctr rc6-192-ofb
 	rc6-256-cfb rc6-256-ctr rc6-256-ofb
@@ -175,16 +175,12 @@ SOCKS Protocol Version 5 (RFC 1928 ).
 
         bf-cfb chacha20 salsa20 
 
-3.The following ciphers recommended by Shadowsocks are not supported yet:
-
-        xchacha20-ietf-poly1305
 
 Please note TLS 1.2 has removed IDEA and DES cipher suites. and because of
 CVE-2016-2183,  http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2183
 , this module has removed all support for DES and 3DES ciphers.
 
-Project website https://github.com/zhou0/shadowsocks-perl
-(Old link https://osdn.net/projects/ssperl/ was the link for the project from 2017 to 2025)
+Project website https://osdn.net/projects/ssperl/
 
 =head1 AUTHOR
 

--- a/bin/ssserver.pl
+++ b/bin/ssserver.pl
@@ -33,7 +33,7 @@ sub main::HELP_MESSAGE()
     print("\tcamellia-256-cfb camellia-256-ctr camellia-256-ofb\n");
     if ($^O ne "MSWin32")
     {
-        print("\tchacha20-ietf chacha20-ietf-poly1305\n");
+        print("\tchacha20-ietf chacha20-ietf-poly1305 xchacha20-ietf-poly1305\n");
     }
 #    print("\trabbit\n");
     print("\trc4-md5\n");
@@ -128,7 +128,7 @@ Usage: ssserver.pl -s SERVER_ADDR -p SERVER_PORT [-b LOCAL_ADDR]
 	camellia-128-cfb camellia-128-ctr camellia-128-ofb
 	camellia-192-cfb camellia-192-ctr camellia-192-ofb
 	camellia-256-cfb camellia-256-ctr camellia-256-ofb
-	chacha20-ietf chacha20-ietf-poly1305
+	chacha20-ietf chacha20-ietf-poly1305 xchacha20-ietf-poly1305
 	rc6-128-cfb rc6-128-ctr rc6-128-ofb
 	rc6-192-cfb rc6-192-ctr rc6-192-ofb
 	rc6-256-cfb rc6-256-ctr rc6-256-ofb
@@ -159,7 +159,7 @@ SOCKS Protocol Version 5 (RFC 1928 ).
 	camellia-128-cfb camellia-128-ctr camellia-128-ofb
 	camellia-192-cfb camellia-192-ctr camellia-192-ofb
 	camellia-256-cfb camellia-256-ctr camellia-256-ofb
-	chacha20-ietf chacha20-ietf-poly1305
+	chacha20-ietf chacha20-ietf-poly1305 xchacha20-ietf-poly1305
 	rc6-128-cfb rc6-128-ctr rc6-128-ofb
 	rc6-192-cfb rc6-192-ctr rc6-192-ofb
 	rc6-256-cfb rc6-256-ctr rc6-256-ofb
@@ -169,16 +169,12 @@ SOCKS Protocol Version 5 (RFC 1928 ).
 
         bf-cfb chacha20 salsa20 
 
-3.The following ciphers recommended by Shadowsocks are not supported yet:
-
-        xchacha20-ietf-poly1305
 
 Please note TLS 1.2 has removed IDEA and DES cipher suites. and because of
 CVE-2016-2183,  http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2183
 , this module has removed all support for DES and 3DES ciphers.
 
-Project website https://github.com/zhou0/shadowsocks-perl
-(Old link https://osdn.net/projects/ssperl/ was the link for the project from 2017 to 2025)
+Project website https://osdn.net/projects/ssperl/
 
 =head1 AUTHOR
 

--- a/lib/Net/Shadowsocks.pm
+++ b/lib/Net/Shadowsocks.pm
@@ -77,6 +77,7 @@ our %_ciphers =
         "camellia-256-ofb" => ['Camellia','ofb',32,16],
         "chacha20-ietf" => [undef,undef,32,12],
         "chacha20-ietf-poly1305" =>  [undef,undef,32,12],
+        "xchacha20-ietf-poly1305" => [undef,undef,32,32],
 #        "rabbit" => ['rabbit','stream',16,16],        
         "rc4-md5"  => ['arcfour','stream',16,16],
         "rc6-128-cfb" => ['RC6','cfb',16,16],
@@ -144,7 +145,7 @@ sub _initialize_cipher($$)
     my $_encrypt_nonce;
     my $_decrypt_nonce;
 
-    if($_method =~ /^chacha20/)
+    if($_method =~ /^(x)?chacha20/)
     {
         if ($_method eq 'chacha20-ietf')
          {
@@ -166,8 +167,8 @@ sub _initialize_cipher($$)
                 #carp ascii_to_hex($_encrypt_subkey);
                 $_decryptor = Crypt::NaCl::Sodium->aead();
                 $_iv = $_encrypt_salt;
-                $_encrypt_nonce = $_encryptor->ietf_nonce("\0");
-                $_decrypt_nonce = $_decryptor->ietf_nonce("\0");
+                $_encrypt_nonce = ($_method =~ /^x/) ? $_encryptor->xietf_nonce("\0") : $_encryptor->ietf_nonce("\0");
+                $_decrypt_nonce = ($_method =~ /^x/) ? $_decryptor->xietf_nonce("\0") : $_decryptor->ietf_nonce("\0");
                 #carp $_encrypt_nonce;
                 #carp ascii_to_hex($_encrypt_nonce);
         }
@@ -371,7 +372,7 @@ Shadowsocks is a secure transport protocol based on SOCKS Protocol Version 5 (RF
 	camellia-128-cfb camellia-128-ctr camellia-128-ofb
 	camellia-192-cfb camellia-192-ctr camellia-192-ofb
 	camellia-256-cfb camellia-256-ctr camellia-256-ofb
-	chacha20-ietf chacha20-ietf-poly1305
+	chacha20-ietf chacha20-ietf-poly1305 xchacha20-ietf-poly1305
 	rc4-md5
 	rc6-128-cfb rc6-128-ctr rc6-128-ofb
 	rc6-192-cfb rc6-192-ctr rc6-192-ofb
@@ -382,9 +383,6 @@ Shadowsocks is a secure transport protocol based on SOCKS Protocol Version 5 (RF
 
       bf-cfb chacha20 salsa20 
 
-3.The following ciphers recommended by Shadowsocks are not supported yet: 
- 
-      xchacha20-ietf-poly1305 
 
 Please note TLS 1.2 has removed IDEA and DES cipher suites. and because of 
 CVE-2016-2183,  http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2183

--- a/lib/Net/Shadowsocks/Client.pm
+++ b/lib/Net/Shadowsocks/Client.pm
@@ -300,7 +300,7 @@ package Net::Shadowsocks::Client;
                                                                     my $data_len_pt;
                                                                     eval
                                                                     {
-                                                                        $data_len_pt = $decryptor->ietf_decrypt($data_len_ct, "", $decrypt_nonce, $decrypt_subkey);
+                                                                        $data_len_pt = ($self->{method} =~ /^x/ ? $decryptor->can("xietf_decrypt") : $decryptor->can("ietf_decrypt"))->($decryptor, $data_len_ct, "", $decrypt_nonce, $decrypt_subkey);
                                                                     };
                                                                     if ( $@ ) 
                                                                     {
@@ -322,7 +322,7 @@ package Net::Shadowsocks::Client;
                                                                         else
                                                                         {
                                                                             $decrypt_nonce = $decrypt_nonce->increment();
-                                                                            $decrypted_data .= $decryptor->ietf_decrypt(substr($incoming_data,18,$data_len + 16),"",$decrypt_nonce,$decrypt_subkey);
+                                                                            $decrypted_data .= ($self->{method} =~ /^x/ ? $decryptor->can("xietf_decrypt") : $decryptor->can("ietf_decrypt"))->($decryptor, substr($incoming_data,18,$data_len + 16),"",$decrypt_nonce,$decrypt_subkey);
                                                                             if ( $@ ) 
                                                                             {
                                                                                 AE::log error =>  "data forged!";
@@ -476,11 +476,11 @@ package Net::Shadowsocks::Client;
                                     else
                                     {
                                         my $header_len_pt = pack('n',length($plain_data));
-                                        my $header_len_ct_withtag = $encryptor ->ietf_encrypt($header_len_pt,"",$encrypt_nonce,$encrypt_subkey);
+                                        my $header_len_ct_withtag = ($self->{method} =~ /^x/ ? $encryptor->can("xietf_encrypt") : $encryptor->can("ietf_encrypt"))->($encryptor, $header_len_pt,"",$encrypt_nonce,$encrypt_subkey);
                                         $encrypt_nonce = $encrypt_nonce->increment();
                                         #carp $encrypt_nonce;
                                         #carp ascii_to_hex($encrypt_nonce);
-                                        my $header_ct_withtag  =  $encryptor->ietf_encrypt($plain_data,"",$encrypt_nonce,$encrypt_subkey);
+                                        my $header_ct_withtag  =  ($self->{method} =~ /^x/ ? $encryptor->can("xietf_encrypt") : $encryptor->can("ietf_encrypt"))->($encryptor, $plain_data,"",$encrypt_nonce,$encrypt_subkey);
                                         $encrypt_nonce = $encrypt_nonce->increment();
                                         #carp $encrypt_nonce;
                                         #carp ascii_to_hex($encrypt_nonce);
@@ -583,7 +583,7 @@ Version 0.9.3.4
 	camellia-128-cfb camellia-128-ctr camellia-128-ofb
 	camellia-192-cfb camellia-192-ctr camellia-192-ofb
 	camellia-256-cfb camellia-256-ctr camellia-256-ofb
-	chacha20-ietf chacha20-ietf-poly1305
+	chacha20-ietf chacha20-ietf-poly1305 xchacha20-ietf-poly1305
 	rc4-md5
 	rc6-128-cfb rc6-128-ctr rc6-128-ofb
 	rc6-192-cfb rc6-192-ctr rc6-192-ofb
@@ -594,16 +594,12 @@ Version 0.9.3.4
 
       bf-cfb chacha20 salsa20 
 
-3.The following ciphers recommended by Shadowsocks are not supported yet: 
- 
-      xchacha20-ietf-poly1305 
 
 Please note TLS 1.2 has removed IDEA and DES cipher suites. and because of 
 CVE-2016-2183,  http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2183
 , this module has removed all support for DES and 3DES ciphers. 
 
-Project website https://github.com/zhou0/shadowsocks-perl
-(Old link https://osdn.net/projects/ssperl/ was the link for the project from 2017 to 2025)
+Project website https://osdn.net/projects/ssperl/
 
 =head1 METHODS
 

--- a/lib/Net/Shadowsocks/Server.pm
+++ b/lib/Net/Shadowsocks/Server.pm
@@ -189,7 +189,7 @@
                                                             my $data_len_pt;
                                                             eval
                                                             {
-                                                                $data_len_pt = $decryptor->ietf_decrypt($data_len_ct, "", $decrypt_nonce, $decrypt_subkey);
+                                                                $data_len_pt = ($self->{method} =~ /^x/ ? $decryptor->can("xietf_decrypt") : $decryptor->can("ietf_decrypt"))->($decryptor, $data_len_ct, "", $decrypt_nonce, $decrypt_subkey);
                                                             };
                                                             if ( $@ ) 
                                                             {
@@ -208,7 +208,7 @@
                                                                 else
                                                                 {
                                                                     $decrypt_nonce = $decrypt_nonce->increment();
-                                                                    $decrypted_data .= $decryptor->ietf_decrypt(substr($incoming_data,18,$data_len + 16),"",$decrypt_nonce,$decrypt_subkey);
+                                                                    $decrypted_data .= ($self->{method} =~ /^x/ ? $decryptor->can("xietf_decrypt") : $decryptor->can("ietf_decrypt"))->($decryptor, substr($incoming_data,18,$data_len + 16),"",$decrypt_nonce,$decrypt_subkey);
                                                                      if ( $@ ) 
                                                                      {
                                                                          AE::log error =>  "data forged!";
@@ -436,9 +436,9 @@
                                                           else
                                                           {
                                                               my $data_len_pt = pack("n",length($plain_data));
-                                                              my $data_len_ct_withtag = $encryptor ->ietf_encrypt($data_len_pt,"",$encrypt_nonce,$encrypt_subkey);
+                                                              my $data_len_ct_withtag = ($self->{method} =~ /^x/ ? $encryptor->can("xietf_encrypt") : $encryptor->can("ietf_encrypt"))->($encryptor, $data_len_pt,"",$encrypt_nonce,$encrypt_subkey);
                                                               $encrypt_nonce = $encrypt_nonce->increment();
-                                                              my $data_ct_withtag  =  $encryptor->ietf_encrypt($plain_data,"",$encrypt_nonce,$encrypt_subkey);
+                                                              my $data_ct_withtag  =  ($self->{method} =~ /^x/ ? $encryptor->can("xietf_encrypt") : $encryptor->can("ietf_encrypt"))->($encryptor, $plain_data,"",$encrypt_nonce,$encrypt_subkey);
                                                               $encrypt_nonce = $encrypt_nonce->increment();
                                                               $encrypted_data = $data_len_ct_withtag . $data_ct_withtag;
                                                               #carp length($encrypted_data);
@@ -530,7 +530,7 @@
                                                             my $data_len_pt;
                                                             eval
                                                             {
-                                                                $data_len_pt = $decryptor->ietf_decrypt($data_len_ct, "", $decrypt_nonce, $decrypt_subkey);
+                                                                $data_len_pt = ($self->{method} =~ /^x/ ? $decryptor->can("xietf_decrypt") : $decryptor->can("ietf_decrypt"))->($decryptor, $data_len_ct, "", $decrypt_nonce, $decrypt_subkey);
                                                             };
                                                             if ( $@ ) 
                                                             {
@@ -549,7 +549,7 @@
                                                                 else
                                                                 {
                                                                     $decrypt_nonce = $decrypt_nonce->increment();
-                                                                    $decrypted_data .= $decryptor->ietf_decrypt(substr($incoming_data,18,$data_len + 16),"",$decrypt_nonce,$decrypt_subkey);
+                                                                    $decrypted_data .= ($self->{method} =~ /^x/ ? $decryptor->can("xietf_decrypt") : $decryptor->can("ietf_decrypt"))->($decryptor, substr($incoming_data,18,$data_len + 16),"",$decrypt_nonce,$decrypt_subkey);
                                                                      if ( $@ ) 
                                                                      {
                                                                          AE::log error =>  "data forged!";
@@ -715,7 +715,7 @@ Version 0.9.3.4
 	camellia-128-cfb camellia-128-ctr camellia-128-ofb
 	camellia-192-cfb camellia-192-ctr camellia-192-ofb
 	camellia-256-cfb camellia-256-ctr camellia-256-ofb
-	chacha20-ietf chacha20-ietf-poly1305
+	chacha20-ietf chacha20-ietf-poly1305 xchacha20-ietf-poly1305
 	rc4-md5
 	rc6-128-cfb rc6-128-ctr rc6-128-ofb
 	rc6-192-cfb rc6-192-ctr rc6-192-ofb
@@ -726,16 +726,12 @@ Version 0.9.3.4
 
       bf-cfb chacha20 salsa20 
 
-3.The following ciphers recommended by Shadowsocks are not supported yet: 
- 
-      xchacha20-ietf-poly1305 
 
 Please note TLS 1.2 has removed IDEA and DES cipher suites. and because of 
 CVE-2016-2183,  http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2183
 , this module has removed all support for DES and 3DES ciphers. 
 
-Project website https://github.com/zhou0/shadowsocks-perl
-(Old link https://osdn.net/projects/ssperl/ was the link for the project from 2017 to 2025)
+Project website https://osdn.net/projects/ssperl/
 
 =head1 METHODS
 


### PR DESCRIPTION
This commit implements the xchacha20-ietf-poly1305 encryption method using Crypt::NaCl::Sodium.

Changes:
- Added xchacha20-ietf-poly1305 to %_ciphers in Net::Shadowsocks.
- Updated _initialize_cipher to use xietf_nonce for xchacha20 methods.
- Updated Net::Shadowsocks::Client and Net::Shadowsocks::Server to dynamically call xietf_encrypt/xietf_decrypt when the xchacha20 method is selected.
- Updated README, README.mkdn, and source file documentation to include the new method and remove it from the "not supported yet" list.
- Updated help messages in ssserver.pl and ssclient.pl.